### PR TITLE
Fix null pointer exception

### DIFF
--- a/src/components/PageTreeEditor.tsx
+++ b/src/components/PageTreeEditor.tsx
@@ -72,7 +72,7 @@ export const PageTreeEditor = ({
 
         if (
           shouldInclude &&
-          (page.title?.toLowerCase().includes(query) || page.slug?.current.toLowerCase().includes(query))
+          (page.title?.toLowerCase().includes(query) || page.slug?.current?.toLowerCase().includes(query))
         ) {
           filteredPages.push(page);
         }


### PR DESCRIPTION
Fixes issue where you run into this error while searching in the page tree UI

![image](https://github.com/Q42/sanity-plugin-page-tree/assets/6125236/e17dcb3d-e091-49a2-94b7-0b3d104087b5)
