### PR TITLE
fix creating page with draft parent

### DIFF
--- a/src/components/PageTreeViewItemActions.tsx
+++ b/src/components/PageTreeViewItemActions.tsx
@@ -26,7 +26,15 @@ export const PageTreeViewItemActions = ({ page, onActionOpen, onActionClose }: P
     const doc = await client.create({
       _id: generateDraftId(),
       _type: type,
-      parent: config.rootSchemaType === type ? undefined : { _type: 'reference', _ref: page._id },
+      parent:
+        config.rootSchemaType === type
+          ? undefined
+          : {
+              _type: 'reference',
+              _ref: page._id,
+              _weak: true,
+              _strengthenOnPublish: { type: page._type },
+            },
       ...(language ? { [language]: page[language] } : {}),
     });
     setNewPage(doc);


### PR DESCRIPTION
Note: this pr is based on #10 

Ran into this issue while creating the fix in #10. 
It turned out it wasn't possible to create a page with an unpublished parent.