### PR TITLE
Fix: draft only parent page referencing

### DIFF
--- a/src/components/PageTreeField.tsx
+++ b/src/components/PageTreeField.tsx
@@ -54,7 +54,9 @@ export const PageTreeField = (
   };
 
   const selectParentPage = (page: PageTreeItem) => {
-    props.inputProps.onChange(set({ _ref: page._id, _type: 'reference' }));
+    props.inputProps.onChange(
+      set({ _ref: page.isDraft ? `${DRAFTS_PREFIX}${page._id}` : page._id, _type: 'reference' }),
+    );
     setOptimisticParentPath(page.path);
     closeDialog();
   };


### PR DESCRIPTION
The `PageTreeField` caused a Sanity desk crash because on change it set the stripped page document id, event if it was a draft. If it is a draft it should be prefixed with `drafts.`.