### PR TITLE
fix case where path was not shown

### DIFF
--- a/src/components/SlugField.tsx
+++ b/src/components/SlugField.tsx
@@ -13,8 +13,8 @@ export const SlugField = (props: SlugFieldProps) => {
   const type = useFormValue(['_type']);
   // eslint-disable-next-line no-warning-comments
   // TODO ideally this would be more type safe.
-  const parentRef = useFormValue(['parent']) as Reference | undefined;
 
+  const parentRef = useFormValue(['parent']) as Reference | undefined;
   const { config, value, renderDefault } = props;
   return (
     <Stack space={3}>
@@ -40,22 +40,33 @@ const UrlExplanation = ({ id, type, parentId, value, config }: UrlExplanationPro
 
   // we use published perspective so we don't get a draft version of the slug that has been changed of a parent page.
   const { page, isLoading } = usePageTreeItem(parentId, config, 'published');
+
   if (isLoading) return null;
 
   const path = page?.path == '/' ? `${page?.path}${value?.current}` : `${page?.path}/${value?.current}`;
 
-  const url = config.baseUrl ? `${config.baseUrl}${path}` : null;
-  const linkToPage = url && (
-    <a href={url} target="blank">
-      {url}
-    </a>
-  );
+  if (!config.baseUrl) {
+    return (
+      <Text muted size={1}>
+        Page url: {path}
+      </Text>
+    );
+  }
 
-  const content = isPublished ? <>Link to page: {linkToPage}</> : <>Page url once published: {url ?? path}</>;
+  const url = `${config.baseUrl}${path}`;
+
+  if (!isPublished) {
+    <Text muted size={1}>
+      Page url once published: {url}
+    </Text>;
+  }
 
   return (
     <Text muted size={1}>
-      {content}
+      Link to page:
+      <a href={url} target="blank">
+        {url}
+      </a>
     </Text>
   );
 };


### PR DESCRIPTION
If you haven't configured a baseUrl, the path was not shown for pages that were unpublished. That is now fixed.
