### PR TITLE
Feature/constrain parent pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ export const pageTreeConfig: PageTreeConfig = {
   /* Root page schema type name */
   rootSchemaType: 'homePage',
   /* Array of all page schema type names */
-  pageSchemaTypes: ['homePage', 'contentPage', 'contentChildPate'],
+  pageSchemaTypes: ['homePage', 'contentPage', 'contentChildPage'],
   /* Optionally specify which document types can be the parent of a document type.
   If no allowed parents are specified for a type, all document types are allowed as a parent for that type */
-  alllowedParents: {
+  allowedParents: {
     contentChildPage: ['contentPage'],
   },
   /* Api version to be used in all underlying Sanity client use */

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ export const pageTreeConfig: PageTreeConfig = {
   /* Array of all page schema type names */
   pageSchemaTypes: ['homePage', 'contentPage', 'contentChildPage'],
   /* Optionally specify which document types can be the parent of a document type.
-  If no allowed parents are specified for a type, all document types are allowed as a parent for that type */
+  If no allowed parents are specified for a type, all document types are allowed as a parent for that type.
+  This config can also be used to prevent certain document types from having any children.*/
   allowedParents: {
     contentChildPage: ['contentPage'],
   },

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ![sanity-plugin-page-tree-studio](https://github.com/Q42/sanity-plugin-page-tree/assets/15087372/45ba349c-13f5-482d-8490-44183b7b448d)
 
 ## Why?
+
 In many example projects for headless CMSs in general, they typically create a post content type with a property like "slug" and serve the post on a route such as `/posts/:slug`. This becomes more complex when dealing with multiple page types and a desire to establish a dynamic page tree.
 
 Consider having three different content types: a home page, an overview page, and a content page, and aiming to create the following URL structure:
@@ -27,6 +28,7 @@ npm i @q42/sanity-plugin-page-tree
 ## Usage in Sanity Studio
 
 ### Create a page tree config
+
 Create a shared page tree config file and constant to use in your page types and desk structure.
 
 ```ts
@@ -37,21 +39,28 @@ export const pageTreeConfig: PageTreeConfig = {
   /* Root page schema type name */
   rootSchemaType: 'homePage',
   /* Array of all page schema type names */
-  pageSchemaTypes: ['homePage', 'contentPage'],
+  pageSchemaTypes: ['homePage', 'contentPage', 'contentChildPate'],
+  /* Optionally specify which document types can be the parent of a document type.
+  If no allowed parents are specified for a type, all document types are allowed as a parent for that type */
+  alllowedParents: {
+    contentChildPage: ['contentPage'],
+  },
   /* Api version to be used in all underlying Sanity client use */
   apiVersion: '2023-12-08',
   /* Optionally provide the field name of the title field of your page documents, to be used to generate a slug automatically for example. */
   titleFieldName: 'title',
   /* Used for showing the full url for a document and linking to it. */
   /* optional, otherwise the path is shown */
-  baseUrl: "https://example.com"
+  baseUrl: 'https://example.com',
 };
 ```
 
 ### Create a page type
+
 The `definePageType` function can be used to wrap your page schema types with the necessary fields (parent (page reference) and slug) for the page tree.
 
 #### Root page (e.g. home page)
+
 Provide the `isRoot` option to the definePageType function to mark the page as a root page. This page won't have a parent and slug field.
 
 ```ts
@@ -68,7 +77,7 @@ const _homePageType = defineType({
 });
 
 export const homePageType = definePageType(_homePageType, pageTreeConfig, {
-  isRoot: true
+  isRoot: true,
 });
 ```
 
@@ -91,6 +100,7 @@ export const contentPageType = definePageType(_contentPageType, pageTreeConfig);
 ```
 
 ### Add page tree to desk structure
+
 Instead of using the default document list for creating and editing pages, you can use the `createPageTreeDocumentList` function to create a custom page tree document list view and add it to your desk structure.
 
 ```ts
@@ -101,19 +111,19 @@ export const structure = (S: StructureBuilder) =>
   S.list()
     .title('Website')
     .items([
-        S.listItem()
-          .title('Pages')
-          .child(
-            createPageTreeDocumentList(S, {
-              config: pageTreeConfig,
-              extendDocumentList: builder => builder.id('pages').title('Pages').apiVersion(pageTreeConfig.apiVersion),
-            }),
-          )
-      ]
-    )
+      S.listItem()
+        .title('Pages')
+        .child(
+          createPageTreeDocumentList(S, {
+            config: pageTreeConfig,
+            extendDocumentList: builder => builder.id('pages').title('Pages').apiVersion(pageTreeConfig.apiVersion),
+          }),
+        ),
+    ]);
 ```
 
 ### Create internal page links
+
 A link to an internal page is a reference to a page document. The `PageTreeField` component can be used to render a custom page tree input in the reference field.
 
 ```ts
@@ -131,6 +141,7 @@ const linkField = defineField({
 ```
 
 ### Document internationalization
+
 This plugin supports the [@sanity/document-internationalization](https://github.com/sanity-io/document-internationalization) plugin. To enable this, do the setup as documented in the plugin and additionally provide the `documentInternationalization` option to the page tree configuration file.
 
 ```ts
@@ -149,14 +160,14 @@ export const pageTreeConfig: PageTreeConfig = {
 };
 ```
 
-
 ## Usage on the frontend
 
 In order to retrieve the right content for a specifc route, you need to make "catch all" route. How this is implemented depends on the framework you are using. Below are some examples for a Next.JS and React single page appication using react router.
 
 ### Regular client
+
 In order to get the page data for the requested path you have to creat a client. Afterwards you can retrieve a list of all the pages with the resolved path and find the correct page metadata.
-With this metadata you can retrieve the data of the document yourself. 
+With this metadata you can retrieve the data of the document yourself.
 
 ```ts
 import { createPageTreeClient } from '@q42/sanity-plugin-page-tree/client';
@@ -177,23 +188,24 @@ async function getPageForPath(path: string) {
 
   return page;
 }
-
 ```
 
-
 ### Next.JS Client
-For users using the App Router of Next.JS with Server Components, we can benefit from the "Request Memoization" feature. 
+
+For users using the App Router of Next.JS with Server Components, we can benefit from the "Request Memoization" feature.
 You can import the dedicated next client:
 
 ```ts
 import { createNextPageTreeClient } from '@q42/sanity-plugin-page-tree/next';
-``` 
+```
 
-This client provides you with some additional helper methods: 
+This client provides you with some additional helper methods:
+
 - `getPageMetadataById` useful for retrieving the url when you have a reference to a page
 - `getPageMetadataByUrl` useful for retrieving the id when you have the path
 
 ## Examples
+
 For full examples, see the following projects:
 
 - [Clean studio](./examples/studio)
@@ -206,14 +218,17 @@ For full examples, see the following projects:
 [MIT](LICENSE) © Q42
 
 ## Develop & test
+
 For local development and testing you need to link and watch the library and link it to any of the studio example projects.
 The basic studio example project, located in `examples/studio`, is a good starting point.
 
 ### Link & watch
+
 - Run `npm install` in the root directory to install the dependencies.
 - Run `npm run link-watch` in the root directory.
 
 ### Example studio
+
 - To run the example studio, go to the `examples/studio` directory.
 - Run `npx yalc add @q42/sanity-plugin-page-tree && npx yalc link @q42/sanity-plugin-page-tree && npm install`
 - Run `npm run dev`

--- a/src/components/PageTreeViewItemActions.tsx
+++ b/src/components/PageTreeViewItemActions.tsx
@@ -47,7 +47,6 @@ export const PageTreeViewItemActions = ({ page, onActionOpen, onActionClose }: P
       navigateUrl({ path });
     }
   }, [newPage, navigateUrl, resolveIntentLink]);
-
   return (
     <Flex gap={1} style={{ flexShrink: 0 }} onClick={e => e.stopPropagation()}>
       <MenuButton
@@ -56,7 +55,12 @@ export const PageTreeViewItemActions = ({ page, onActionOpen, onActionClose }: P
         menu={
           <Menu>
             {config.pageSchemaTypes
-              .filter(type => type !== config.rootSchemaType)
+              .filter(
+                type =>
+                  type !== config.rootSchemaType &&
+                  (config.alllowedParents?.[type] === undefined ||
+                    config.alllowedParents?.[type]?.includes(page._type)),
+              )
               .map(type => (
                 <MenuItem key={type} onClick={() => onAdd(type)} text={schema.get(type)?.title ?? type} value={type} />
               ))}

--- a/src/components/PageTreeViewItemActions.tsx
+++ b/src/components/PageTreeViewItemActions.tsx
@@ -58,8 +58,7 @@ export const PageTreeViewItemActions = ({ page, onActionOpen, onActionClose }: P
               .filter(
                 type =>
                   type !== config.rootSchemaType &&
-                  (config.alllowedParents?.[type] === undefined ||
-                    config.alllowedParents?.[type]?.includes(page._type)),
+                  (config.allowedParents?.[type] === undefined || config.allowedParents?.[type]?.includes(page._type)),
               )
               .map(type => (
                 <MenuItem key={type} onClick={() => onAdd(type)} text={schema.get(type)?.title ?? type} value={type} />

--- a/src/components/PageTreeViewItemActions.tsx
+++ b/src/components/PageTreeViewItemActions.tsx
@@ -62,7 +62,7 @@ export const PageTreeViewItemActions = ({ page, onActionOpen, onActionClose }: P
   const tooltipContent = isAddPageButtonDisabled ? (
     <Box padding={1}>
       <Text muted size={1}>
-        The allowed parents configuration prevents this document type from being a parent to any other document.
+        This page cannot have any child pages.
       </Text>
     </Box>
   ) : undefined;

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -12,3 +12,7 @@ export const getRawPageMetadataQuery = (config: PageTreeConfig) => `*[_type in [
     title,
     ${getLanguageFromConfig(config) ?? ''}
   }`;
+
+export const getDocumentTypeQuery = (documentId: string) => `*[_id == "${documentId}"]{
+  _type
+}`;

--- a/src/schema/definePageType.ts
+++ b/src/schema/definePageType.ts
@@ -3,6 +3,7 @@ import { PageTreeField } from '../components/PageTreeField';
 import { PageTreeConfig } from '../types';
 import { slugValidator } from '../validators/slug-validator';
 import { SlugField } from '../components/SlugField';
+import { allowedParentValidator } from '../validators/parent-validator';
 
 type Options = {
   isRoot?: boolean;
@@ -54,7 +55,7 @@ const basePageFields = (config: PageTreeConfig, options: Options, ownType: Docum
           title: 'Parent page',
           type: 'reference',
           to: getPossibleParentsFromConfig(config, ownType).map(type => ({ type })),
-          validation: Rule => Rule.required(),
+          validation: Rule => Rule.required().custom(allowedParentValidator(config, ownType.name)),
           group: options.fieldsGroupName,
           components: {
             field: props => PageTreeField({ ...props, config, mode: 'select-parent' }),

--- a/src/schema/definePageType.ts
+++ b/src/schema/definePageType.ts
@@ -11,6 +11,13 @@ type Options = {
   slugSource?: SlugOptions['source'];
 };
 
+function getPossibleParentsFromConfig(config: PageTreeConfig, ownType: DocumentDefinition): string[] {
+  if (config.alllowedParents !== undefined && ownType.name in config.alllowedParents) {
+    return config.alllowedParents[ownType.name];
+  }
+  return config.pageSchemaTypes;
+}
+
 export const definePageType = (
   type: DocumentDefinition,
   config: PageTreeConfig,
@@ -19,10 +26,10 @@ export const definePageType = (
   defineType({
     ...type,
     title: type.title,
-    fields: [...basePageFields(config, options), ...type.fields],
+    fields: [...basePageFields(config, options, type), ...type.fields],
   });
 
-const basePageFields = (config: PageTreeConfig, options: Options) => [
+const basePageFields = (config: PageTreeConfig, options: Options, ownType: DocumentDefinition) => [
   ...(!options.isRoot
     ? [
         defineField({
@@ -47,7 +54,7 @@ const basePageFields = (config: PageTreeConfig, options: Options) => [
           name: 'parent',
           title: 'Parent page',
           type: 'reference',
-          to: config.pageSchemaTypes.map(type => ({ type })),
+          to: getPossibleParentsFromConfig(config, ownType).map(type => ({ type })),
           validation: Rule => Rule.required(),
           group: options.fieldsGroupName,
           components: {

--- a/src/schema/definePageType.ts
+++ b/src/schema/definePageType.ts
@@ -1,5 +1,4 @@
 import { DocumentDefinition, defineField, defineType, SlugOptions } from 'sanity';
-
 import { PageTreeField } from '../components/PageTreeField';
 import { PageTreeConfig } from '../types';
 import { slugValidator } from '../validators/slug-validator';

--- a/src/schema/definePageType.ts
+++ b/src/schema/definePageType.ts
@@ -12,8 +12,8 @@ type Options = {
 };
 
 function getPossibleParentsFromConfig(config: PageTreeConfig, ownType: DocumentDefinition): string[] {
-  if (config.alllowedParents !== undefined && ownType.name in config.alllowedParents) {
-    return config.alllowedParents[ownType.name];
+  if (config.allowedParents !== undefined && ownType.name in config.allowedParents) {
+    return config.allowedParents[ownType.name];
   }
   return config.pageSchemaTypes;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,7 +47,7 @@ export type PageTreeConfig = {
   pageSchemaTypes: string[];
   /* Field name of your page documents */
   titleFieldName?: string;
-  /* Specify which document types can be the parent of another document type */
+  /* Optionally specify which document types can be the parent of a document type */
   alllowedParents?: Record<string, string[]>;
   /* Used for creating page link on the editor page */
   baseUrl?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,7 +48,7 @@ export type PageTreeConfig = {
   /* Field name of your page documents */
   titleFieldName?: string;
   /* Optionally specify which document types can be the parent of a document type */
-  alllowedParents?: Record<string, string[]>;
+  allowedParents?: Record<string, string[]>;
   /* Used for creating page link on the editor page */
   baseUrl?: string;
   /* This plugin supports the document-internationalization plugin. To use it properly, provide the supported languages. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,8 @@ export type PageTreeConfig = {
   pageSchemaTypes: string[];
   /* Field name of your page documents */
   titleFieldName?: string;
+  /* Specify which document types can be the parent of another document type */
+  alllowedParents?: Record<string, string[]>;
   /* Used for creating page link on the editor page */
   baseUrl?: string;
   /* This plugin supports the document-internationalization plugin. To use it properly, provide the supported languages. */

--- a/src/validators/parent-validator.ts
+++ b/src/validators/parent-validator.ts
@@ -9,9 +9,9 @@ import { RawPageMetadata, PageTreeConfig, SanityRef } from '../types';
 export const allowedParentValidator =
   (config: PageTreeConfig, ownType: string) =>
   async (selectedParent: Reference | undefined, context: ValidationContext) => {
-    const alllowedParents = config.alllowedParents?.[ownType];
+    const allowedParents = config.allowedParents?.[ownType];
 
-    if (alllowedParents === undefined) {
+    if (allowedParents === undefined) {
       return true;
     }
 
@@ -34,7 +34,7 @@ export const allowedParentValidator =
       return 'Unable to check the type of the selected parent.';
     }
 
-    if (!alllowedParents.includes(selectedParentType)) {
+    if (!allowedParents.includes(selectedParentType)) {
       return `The parent of type "${selectedParentType}" is not allowed for this type of document.`;
     }
 

--- a/src/validators/parent-validator.ts
+++ b/src/validators/parent-validator.ts
@@ -1,0 +1,42 @@
+import { Reference, ValidationContext } from 'sanity';
+
+import { getDocumentTypeQuery } from '../queries';
+import { RawPageMetadata, PageTreeConfig, SanityRef } from '../types';
+
+/**
+ * Validates that the slug is unique within the parent page and therefore that entire the path is unique.
+ */
+export const allowedParentValidator =
+  (config: PageTreeConfig, ownType: string) =>
+  async (selectedParent: Reference | undefined, context: ValidationContext) => {
+    const alllowedParents = config.alllowedParents?.[ownType];
+
+    if (alllowedParents === undefined) {
+      return true;
+    }
+
+    const parentRef = context.document?.parent as SanityRef | undefined;
+    if (!parentRef) {
+      return true;
+    }
+
+    const parentId = parentRef._ref;
+
+    if (parentId === undefined) {
+      return true;
+    }
+
+    const client = context.getClient({ apiVersion: config.apiVersion });
+    const selectedParentType = (await client.fetch<Pick<RawPageMetadata, '_type'>[]>(getDocumentTypeQuery(parentId)))[0]
+      ?._type;
+
+    if (!selectedParentType) {
+      return 'Unable to check the type of the selected parent.';
+    }
+
+    if (!alllowedParents.includes(selectedParentType)) {
+      return `The parent of type "${selectedParentType}" is not allowed for this type of document.`;
+    }
+
+    return true;
+  };


### PR DESCRIPTION
This PR expands the tree config with an option to define, for each document type, which types of documents they can have as parents. 

This feature has been implemented in three areas:
- The generation of the parent field defenition. There, the references to also take this (optional) setting into account.
- The new-page + button menu in the page tree layout.
- If the above two fail, there is also a validator that fetches the type of the selected parent document and validates it against the allowed parent types, of those are available.

