### PR TITLE
implement sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ export const pageTreeConfig: PageTreeConfig = {
   ...,
   /* Configuration to make this plugin work with the @sanity/document-internationalization plugin */
   documentInternationalization: {
-    /* Supported languages */
+    /* Supported languages. Note that, the order is used in the page tree view. */
     supportedLanguages: ['en', 'nl'],
     /* Optionally change the languageField, like you can do in the original plugin */
     languageField: 'locale', // Defaults to 'language'

--- a/src/helpers/page-tree.ts
+++ b/src/helpers/page-tree.ts
@@ -1,4 +1,4 @@
-import { groupBy, omit, orderBy } from 'lodash';
+import { groupBy, isNil, omit, orderBy, sortBy } from 'lodash';
 
 import {
   RawPageMetadata,
@@ -47,7 +47,20 @@ export const findPageTreeItemById = (pages: PageTreeItem[], id: string): PageTre
 export const mapRawPageMetadatasToPageTree = (config: PageTreeConfig, pages: RawPageMetadata[]): PageTreeItem[] => {
   const pagesWithPublishedState = getPublishedAndDraftRawPageMetdadata(config, pages);
 
-  return orderBy(mapPageTreeItems(config, pagesWithPublishedState), 'path');
+  const orderedPages = orderBy(mapPageTreeItems(config, pagesWithPublishedState), 'path');
+  const { documentInternationalization } = config;
+  if (documentInternationalization) {
+    const languageField = documentInternationalization.languageFieldName ?? 'language';
+
+    return sortBy(orderedPages, p => {
+      let index = documentInternationalization.supportedLanguages.indexOf((p[languageField] as string)?.toLowerCase());
+      if (index === -1) {
+        index = documentInternationalization.supportedLanguages.length;
+      }
+      return index;
+    });
+  }
+  return orderedPages;
 };
 
 /**


### PR DESCRIPTION
Note: based on https://github.com/Q42/sanity-plugin-page-tree/pull/25

Let the order of supported languages define the order these roots are shown in the page tree view.