### PR TITLE
Add additional validation rules for slugs, including lower case and valid characters

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,14 @@ export type PageTreeConfig = {
     /* Optional field name of the language field, defaults to "language" */
     languageFieldName?: string;
   };
+  /* Optionally add any filtering rules */
+  slugValidationOptions?: {
+    /* Slugs must be lowercase or fail validation */
+    enforceLowerCase?: boolean;
+    /* Slugs cannot contain invalid characters or fail validation */
+    /* Invalid characters include: */
+    enforceValidCharacters?: boolean;
+  }
 };
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,12 +58,11 @@ export type PageTreeConfig = {
     /* Optional field name of the language field, defaults to "language" */
     languageFieldName?: string;
   };
-  /* Optionally add any filtering rules */
+  /* Optionally add any validation rules for slugs */
   slugValidationOptions?: {
     /* Slugs must be lowercase or fail validation */
     enforceLowerCase?: boolean;
     /* Slugs cannot contain invalid characters or fail validation */
-    /* Invalid characters include: */
     enforceValidCharacters?: boolean;
   }
 };

--- a/src/validators/slug-validator.ts
+++ b/src/validators/slug-validator.ts
@@ -39,6 +39,17 @@ export const slugValidator =
         ? `Slug must be unique. Another page with the same slug is already published, but has a draft version with a  different slug: "${siblingDraftPageWithSameSlug.slug?.current}". Publish that page first or change the slug to something else.`
         : 'Slug must be unique.';
     }
+    
+    // Additional validation rules applied if configured
+    // Check if slug is lowercase.
+    if (config.slugValidationOptions?.enforceLowerCase === true && slug?.current !== slug?.current?.toLowerCase()) {
+        return "Slug must be lower case.";
+    }
+
+    // Allow A-z, 0-9, -, ., _, ~, :, and /
+    if (config.slugValidationOptions?.enforceValidCharacters === true && slug?.current && /[^A-Za-z0-9\-._~:\/]/.test(slug?.current)) {
+        return "Slug must not contain invalid characters."
+    }
 
     return true;
   };


### PR DESCRIPTION
This pull request adds a feature that may be helpful for some: additional validation rules for the slug field.

In our instance, we have some users that are trying to add things like spaces or other weird characters rather than generating the slug with the button. While we are actively trying to not have that happen, we figured it may help if there was a validation rule to do this.

Another issue is that we're trying to enforce lowercase routes. While we can likely do this later in the build process, it may just help to enforce it here as well.

That's how this popped up. We're open to any feedback or anything else that should be done here. Really appreciate the time you've all put into this. It's very helpful!