### PR TITLE
Added ability to provide custom slug validation

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { DocumentListBuilder } from 'sanity/structure';
+import { SlugOptions, SlugRule, SlugValue, ValidationBuilder } from 'sanity';
 
 export type SanityRef = {
   _ref: string;
@@ -35,29 +36,37 @@ export type PageTreeItem = RawPageMetadataWithPublishedState & {
   path: string;
 };
 
+export type GlobalOptions = {
+  fieldsGroupName?: string;
+  slugSource?: SlugOptions['source'];
+  slugValidationRules?: ValidationBuilder<SlugRule, SlugValue>
+}
+
 /**
  * @public
  */
 export type PageTreeConfig = {
-  /* Api version that is used throughout your project */
+  /** Api version that is used throughout your project */
   apiVersion: string;
-  /* Root page schema type name, e.g. "homePage" */
+  /** Root page schema type name, e.g. "homePage" */
   rootSchemaType: string;
-  /* All your page schema type names, e.g. ["homePage", "contentPage"] */
+  /** All your page schema type names, e.g. ["homePage", "contentPage"] */
   pageSchemaTypes: string[];
-  /* Field name of your page documents */
+  /** @deprecated Use globalOptions.slugSource instead. Field name of your page documents */
   titleFieldName?: string;
-  /* Optionally specify which document types can be the parent of a document type */
+  /** Optionally specify which document types can be the parent of a document type */
   allowedParents?: Record<string, string[]>;
-  /* Used for creating page link on the editor page */
+  /** Used for creating page link on the editor page */
   baseUrl?: string;
-  /* This plugin supports the document-internationalization plugin. To use it properly, provide the supported languages. */
+  /** This plugin supports the document-internationalization plugin. To use it properly, provide the supported languages. */
   documentInternationalization?: {
-    /* Array of supported language code strings, e.g. ["en", "nl"]. These will be used in root pages and when creating a new child page it will set the language field based on the parent page. */
+    /** Array of supported language code strings, e.g. ["en", "nl"]. These will be used in root pages and when creating a new child page it will set the language field based on the parent page. */
     supportedLanguages: string[];
-    /* Optional field name of the language field, defaults to "language" */
+    /** Optional field name of the language field, defaults to "language" */
     languageFieldName?: string;
   };
+  /** Define options that apply to all pages. Can be overridden by options supplied using definePageType */
+  globalOptions?: GlobalOptions
 };
 
 /**


### PR DESCRIPTION
The validation rules can be supplied either to each `definePageTree` option or to a new `globalOptions`. This also fixes the problem where the `titleFieldName` is preferred ahead of the `slugSource` provided to a specific page definition.