### PR TITLE
Archived pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,10 @@ export const pageTreeConfig: PageTreeConfig = {
   apiVersion: '2023-12-08',
   /* Optionally provide the field name of the title field of your page documents, to be used to generate a slug automatically for example. */
   titleFieldName: 'title',
+  /* Optionally provide the field name of the archived field. If configured, it will hide pages from the tree if this field is set to true.  */
+  archivedFieldName: 'isArchived',
   /* Used for showing the full url for a document and linking to it. */
-  /* optional, otherwise the path is shown */
+  /* Optional, otherwise the path is shown */
   baseUrl: 'https://example.com',
 };
 ```

--- a/src/helpers/page-tree.ts
+++ b/src/helpers/page-tree.ts
@@ -102,7 +102,7 @@ const mapPageTreeItems = (
 };
 
 /**
- * Provides draft and published status. Filters out duplicate pages with the same id and invalid pages.
+ * Provides draft and published status. Filters out duplicate pages with the same id, invalid and archived pages.
  */
 const getPublishedAndDraftRawPageMetadata = (
   config: PageTreeConfig,
@@ -119,6 +119,7 @@ const getPublishedAndDraftRawPageMetadata = (
 
   return pages
     .filter(page => isValidPage(config, page))
+    .filter(page => !isArchivedPage(config, page))
     .filter(p => !draftPages[p._id]) // filter out published versions for pages which have a draft
     .map(p => {
       const isDraft = p._id.startsWith(DRAFTS_PREFIX);
@@ -140,4 +141,8 @@ const isValidPage = (config: PageTreeConfig, page: RawPageMetadata): boolean => 
     }
   }
   return true;
+};
+
+const isArchivedPage = (config: PageTreeConfig, page: RawPageMetadata): boolean => {
+  return config.archivedFieldName ? page[config.archivedFieldName] === true : false;
 };

--- a/src/helpers/page-tree.ts
+++ b/src/helpers/page-tree.ts
@@ -144,5 +144,5 @@ const isValidPage = (config: PageTreeConfig, page: RawPageMetadata): boolean => 
 };
 
 const isArchivedPage = (config: PageTreeConfig, page: RawPageMetadata): boolean => {
-  return config.archivedFieldName ? page[config.archivedFieldName] === true : false;
+  return !!config.archivedFieldName && page[config.archivedFieldName] === true;
 };

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -20,4 +20,5 @@ export const rawPageMetadataFragment = (config: PageTreeConfig) => `
     parent,
     slug,
     title,
+    ${config.archivedFieldName ? `${config.archivedFieldName},` : ''}
     ${getLanguageFieldName(config) ?? ''}`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,8 +48,10 @@ export type PageTreeConfig = {
   rootSchemaType: string;
   /* All your page schema type names, e.g. ["homePage", "contentPage"] */
   pageSchemaTypes: string[];
-  /* Field name of your page documents */
+  /* Field name of the title your page documents */
   titleFieldName?: string;
+  /* Field name of the archived field. If configured, it will hide pages from the tree if this field is set to true */
+  archivedFieldName?: string;
   /* Optionally specify which document types can be the parent of a document type */
   allowedParents?: Record<string, string[]>;
   /* Used for creating page link on the editor page */


### PR DESCRIPTION
Adds an optional config option `archivedFieldName`. When configured this boolean field on pages will be used to hide these pages from the page tree if `true`.

The feature is intended to be used in combination with setting up a document list in the studio structure of your project that shows all these archived pages. This way the page tree can be kept more clean for studio users. Whether 'archived' means that it will be available in the client is up to you.