### PR TITLE
Fix undefined filter config

### DIFF
--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -6,7 +6,7 @@ export const getAllRawPageMetadataQuery = (config: PageTreeConfig) => `*[_type i
 )
   .map(key => `"${key}"`)
   .join(', ')}]
-  ${config?.filter && ` && ${config.filter}`}
+  ${config?.filter ? ` && ${config.filter}` : ''}
 ]{
     ${rawPageMetadataFragment(config)}
   }`;


### PR DESCRIPTION
Fixes #47 

There was a bug where the optional filter config option caused a malformed GROQ query if left undefined.