### PR TITLE
Fix showing page tree items without slug

### DIFF
--- a/src/components/PageTreeViewItem.tsx
+++ b/src/components/PageTreeViewItem.tsx
@@ -110,7 +110,7 @@ export const PageTreeViewItem = ({
             onClick={onItemClick}>
             <Flex align="center" gap={3}>
               <UrlText isDisabled={isDisabled || (!page.isPublished && page.isDraft)} textOverflow="ellipsis">
-                {parentPath ? page.slug?.current : getRootPageSlug(page, config) ?? '/'}
+                {parentPath ? page.slug?.current ?? 'untitled' : getRootPageSlug(page, config) ?? '/'}
               </UrlText>
               {!isDisabled && (isHovered || hasActionOpen) && (
                 <PageTreeViewItemActions

--- a/src/helpers/page-tree.ts
+++ b/src/helpers/page-tree.ts
@@ -89,7 +89,7 @@ const mapPageTreeItems = (
 
   return getChildPages(parentId).map(page => {
     const pagePath = parentPath
-      ? `${parentPath === '/' ? '' : parentPath}/${page.slug?.current}`
+      ? `${parentPath === '/' ? '' : parentPath}/${page.slug?.current ?? ''}`
       : `/${getRootPageSlug(page, config) ?? ''}`;
     const children = orderBy(mapPageTreeItems(config, pagesWithPublishedState, page._id, pagePath), 'path');
 
@@ -134,7 +134,7 @@ const getPublishedAndDraftRawPageMetadata = (
 };
 
 const isValidPage = (config: PageTreeConfig, page: RawPageMetadata): boolean => {
-  if (!page.parent || !page.slug) {
+  if (!page.parent) {
     if (page._type !== config.rootSchemaType) {
       return false;
     }


### PR DESCRIPTION
Currently if any page was added to the page tree and the user did not add a title/slug the page is not shown in the tree. Once you close the editor it is hard to find again and results in unused draft pages.

This fix shows these pages as `untitled` in the tree so that they can be updated or removed by users.