### PR TITLE
Prevent untranslated apps from having a `language` field

### DIFF
--- a/src/components/PageTreeViewItemActions.tsx
+++ b/src/components/PageTreeViewItemActions.tsx
@@ -23,7 +23,8 @@ export const PageTreeViewItemActions = ({ page, onActionOpen, onActionClose }: P
   const [newPage, setNewPage] = useState<{ _id: string; _type: string } | undefined>();
 
   const onAdd = async (type: string) => {
-    const language = getLanguageFieldName(config);
+    const language = config.documentInternationalization ? getLanguageFieldName(config) : undefined;
+
     const doc = await client.create({
       _id: generateDraftId(),
       _type: type,

--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -1,7 +1,8 @@
 import { PageTreeConfig, RawPageMetadata } from '../types';
 
-export const getLanguageFieldName = (config: PageTreeConfig) =>
-  config.documentInternationalization?.languageFieldName ?? 'language';
+export const getLanguageFieldName = (config: PageTreeConfig) => {
+  return config.documentInternationalization?.languageFieldName ?? 'language';
+};
 
 export const getRootPageSlug = (page: RawPageMetadata, config: PageTreeConfig) => {
   if (!config.documentInternationalization) return;

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -22,4 +22,4 @@ export const rawPageMetadataFragment = (config: PageTreeConfig) => `
     parent,
     slug,
     title,
-    ${getLanguageFieldName(config) ?? ''}`;
+    ${config.documentInternationalization ? getLanguageFieldName(config) : ''}`;


### PR DESCRIPTION
Apps without any localization options still had a `language` field, which would be set to null.

Fixes #50 

<img width="635" alt="Screenshot 2025-02-19 at 14 05 18" src="https://github.com/user-attachments/assets/f066cb8f-3a7e-4d74-8081-10ba00d9e624" />
