### PR TITLE
Hide create page button while referring to a page

### DIFF
--- a/src/components/PageTreeEditor.tsx
+++ b/src/components/PageTreeEditor.tsx
@@ -18,6 +18,7 @@ export type PageTreeEditorProps = {
   disabledItemIds?: string[];
   initialOpenItemIds?: string[];
   allowedPageTypes?: string[];
+  hideActions?: boolean;
 };
 
 type PageTreeState = {
@@ -33,6 +34,7 @@ export const PageTreeEditor = ({
   disabledItemIds,
   initialOpenItemIds,
   allowedPageTypes,
+  hideActions,
 }: PageTreeEditorProps) => {
   const config = usePageTreeConfig();
   const client = useClient({ apiVersion: config.apiVersion });
@@ -147,6 +149,7 @@ export const PageTreeEditor = ({
               forceOpen={!!pageTreeState.query}
               isRoot
               onClick={onItemClick}
+              hideActions={hideActions}
             />
           ))}
         </Flex>
@@ -155,7 +158,7 @@ export const PageTreeEditor = ({
           <Box paddingX={3} paddingY={3}>
             <Text>No pages found</Text>
           </Box>
-          <AddButton mode="ghost" icon={AddIcon} text="Add root page" onClick={addRootPage} />
+          {!hideActions && <AddButton mode="ghost" icon={AddIcon} text="Add root page" onClick={addRootPage} />}
         </>
       )}
     </Flex>

--- a/src/components/PageTreeField.tsx
+++ b/src/components/PageTreeField.tsx
@@ -6,7 +6,7 @@ import { PageTreeInput } from './PageTreeInput';
 export const PageTreeField = (
   props: ObjectFieldProps<ReferenceValue> & {
     config: PageTreeConfig;
-
+    hideActions?: boolean;
     mode?: 'select-parent' | 'select-page';
     inputProps: { schemaType: { to?: { name: string }[] } };
   },
@@ -19,7 +19,7 @@ export const PageTreeField = (
 
   return (
     <FormField title={props.title} inputId={props.inputId} validation={props.validation}>
-      <PageTreeInput {...inputProps} />
+      <PageTreeInput {...inputProps} hideActions />
     </FormField>
   );
 };

--- a/src/components/PageTreeInput.tsx
+++ b/src/components/PageTreeInput.tsx
@@ -16,6 +16,7 @@ export const PageTreeInput = (
     config: PageTreeConfig;
     mode?: 'select-parent' | 'select-page';
     schemaType: { to?: { name: string }[] };
+    hideActions?: boolean;
   },
 ) => {
   const mode = props.mode ?? 'select-page';
@@ -82,7 +83,7 @@ export const PageTreeInput = (
         ) : (
           <Card padding={1} shadow={1} radius={2}>
             <SelectedItemCard padding={3} radius={2} onClick={openDialog}>
-              <Text size={2}>{parentId ? parentPath ?? 'Select page' : 'Select page'}</Text>
+              <Text size={2}>{parentId ? (parentPath ?? 'Select page') : 'Select page'}</Text>
             </SelectedItemCard>
           </Card>
         )}
@@ -102,6 +103,7 @@ export const PageTreeInput = (
               onItemClick={selectParentPage}
               disabledItemIds={disabledParentIds}
               initialOpenItemIds={openItemIds}
+              hideActions={props.hideActions}
             />
           </Box>
         </Dialog>

--- a/src/components/PageTreeInput.tsx
+++ b/src/components/PageTreeInput.tsx
@@ -83,7 +83,7 @@ export const PageTreeInput = (
         ) : (
           <Card padding={1} shadow={1} radius={2}>
             <SelectedItemCard padding={3} radius={2} onClick={openDialog}>
-              <Text size={2}>{parentId ? (parentPath ?? 'Select page') : 'Select page'}</Text>
+              <Text size={2}>{parentId ? parentPath ?? 'Select page' : 'Select page'}</Text>
             </SelectedItemCard>
           </Card>
         )}

--- a/src/components/PageTreeViewItem.tsx
+++ b/src/components/PageTreeViewItem.tsx
@@ -57,7 +57,7 @@ export const PageTreeViewItem = ({
     navigateIntent('edit', { id: page._id, type: page._type });
   };
 
-  const path = parentPath ? `${parentPath}/${page.slug?.current}` : (getLanguageFieldName(config) ?? '/');
+  const path = parentPath ? `${parentPath}/${page.slug?.current}` : getLanguageFieldName(config) ?? '/';
   const hasChildren = page.children.length > 0;
 
   const currentPageNumber = routerPanesState[groupIndex + 1]?.[0]?.id;
@@ -112,7 +112,7 @@ export const PageTreeViewItem = ({
             onClick={onItemClick}>
             <Flex align="center" gap={3}>
               <UrlText isDisabled={isDisabled || (!page.isPublished && page.isDraft)} textOverflow="ellipsis">
-                {parentPath ? page.slug?.current : (getRootPageSlug(page, config) ?? '/')}
+                {parentPath ? page.slug?.current : getRootPageSlug(page, config) ?? '/'}
               </UrlText>
               {!isDisabled && !hideActions && (isHovered || hasActionOpen) && (
                 <PageTreeViewItemActions

--- a/src/components/PageTreeViewItem.tsx
+++ b/src/components/PageTreeViewItem.tsx
@@ -22,6 +22,7 @@ export type PageTreeViewItemProps = {
   forceOpen?: boolean;
   isRoot?: boolean;
   allowedPageTypes?: string[];
+  hideActions?: boolean;
 };
 
 export const PageTreeViewItem = ({
@@ -34,6 +35,7 @@ export const PageTreeViewItem = ({
   allowedPageTypes,
   forceOpen,
   isRoot,
+  hideActions,
 }: PageTreeViewItemProps) => {
   const config = usePageTreeConfig();
   const { navigateIntent, routerPanesState, groupIndex } = usePaneRouter();
@@ -55,7 +57,7 @@ export const PageTreeViewItem = ({
     navigateIntent('edit', { id: page._id, type: page._type });
   };
 
-  const path = parentPath ? `${parentPath}/${page.slug?.current}` : getLanguageFieldName(config) ?? '/';
+  const path = parentPath ? `${parentPath}/${page.slug?.current}` : (getLanguageFieldName(config) ?? '/');
   const hasChildren = page.children.length > 0;
 
   const currentPageNumber = routerPanesState[groupIndex + 1]?.[0]?.id;
@@ -110,9 +112,9 @@ export const PageTreeViewItem = ({
             onClick={onItemClick}>
             <Flex align="center" gap={3}>
               <UrlText isDisabled={isDisabled || (!page.isPublished && page.isDraft)} textOverflow="ellipsis">
-                {parentPath ? page.slug?.current : getRootPageSlug(page, config) ?? '/'}
+                {parentPath ? page.slug?.current : (getRootPageSlug(page, config) ?? '/')}
               </UrlText>
-              {!isDisabled && (isHovered || hasActionOpen) && (
+              {!isDisabled && !hideActions && (isHovered || hasActionOpen) && (
                 <PageTreeViewItemActions
                   page={page}
                   onActionOpen={() => setHasActionOpen(true)}
@@ -139,6 +141,7 @@ export const PageTreeViewItem = ({
                     allowedPageTypes={allowedPageTypes}
                     forceOpen={forceOpen}
                     onClick={onClick}
+                    hideActions={hideActions}
                   />
                 ))}
               </Stack>


### PR DESCRIPTION
If you currently use the PageTreeField as a custom input field for creating a reference to another page, on hover we show a create page button which makes no sense in that context. This hasn't been intended behaviour and this PR removes this. It also fixes #42 