### PR TITLE
fix: make the link in studio example optional so it doesn't block itself

### DIFF
--- a/examples/studio/schemas/index.ts
+++ b/examples/studio/schemas/index.ts
@@ -36,19 +36,16 @@ const _homePageType = defineType({
       name: 'link',
       title: 'Link',
       type: 'object',
-      validation: (Rule: ObjectRule) => Rule.required(),
       fields: [
         defineField({
           name: 'title',
           title: 'Title',
           type: 'string',
-          validation: Rule => Rule.required(),
         }),
         defineField({
           name: 'page',
           title: 'Page',
           type: 'reference',
-          validation: Rule => Rule.required(),
           to: [{ type: 'contentPage' }, { type: 'homePage' }],
           components: {
             field: props => PageTreeField({ ...props, config: pageTreeConfig }),


### PR DESCRIPTION
Just some maintenance.
You couldn't publish the home page because the link was required. But you couldn't make any other pages because the home page couldn't be published. So this conflicted with itself.