### PR TITLE
fix: let build, lint, test run on PRs instead of push

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -1,6 +1,8 @@
 name: Build, lint, and test
 
-on: [push]
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
 
 jobs:
   build-and-test:


### PR DESCRIPTION
## Description of changes

Make sure that this workflow runs on PR instead of push. Then forks can, after approval, also run this workflow.
