### PR TITLE
Fix Scheduled Drafts in the Site Tree/Validation

### DIFF
--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -6,6 +6,7 @@ export const getAllRawPageMetadataQuery = (config: PageTreeConfig) => `*[_type i
 )
   .map(key => `"${key}"`)
   .join(', ')}]
+  && !(_id match "versions.*")
   ${config?.filter ? ` && ${config.filter}` : ''}
 ]{
     ${rawPageMetadataFragment(config)}

--- a/src/utils/sanity.ts
+++ b/src/utils/sanity.ts
@@ -9,8 +9,7 @@ export const getSanityDocumentId = (val: string): string => {
   if (val.startsWith(DRAFTS_PREFIX)) return val.slice(DRAFTS_PREFIX.length);
   if (val.startsWith(VERSION_PREFIX)) {
     const withoutVersion = val.slice(VERSION_PREFIX.length);
-    const dotIndex = withoutVersion.indexOf('.');
-    return dotIndex >= 0 ? withoutVersion.slice(dotIndex + 1) : withoutVersion;
+    return withoutVersion.slice(withoutVersion.indexOf('.') + 1);
   }
   return val;
 };

--- a/src/utils/sanity.ts
+++ b/src/utils/sanity.ts
@@ -1,6 +1,16 @@
 export const DRAFTS_PREFIX = 'drafts.';
+export const VERSION_PREFIX = 'versions.';
 
 /**
- * Strips draft id prefix from Sanity document id when draft id is provided.
+ * Strips draft or version id prefix from Sanity document id.
+ * Handles: 'drafts.<id>' and 'versions.<bundleId>.<id>'
  */
-export const getSanityDocumentId = (val: string) => val.replace(DRAFTS_PREFIX, '');
+export const getSanityDocumentId = (val: string): string => {
+  if (val.startsWith(DRAFTS_PREFIX)) return val.slice(DRAFTS_PREFIX.length);
+  if (val.startsWith(VERSION_PREFIX)) {
+    const withoutVersion = val.slice(VERSION_PREFIX.length);
+    const dotIndex = withoutVersion.indexOf('.');
+    return dotIndex >= 0 ? withoutVersion.slice(dotIndex + 1) : withoutVersion;
+  }
+  return val;
+};

--- a/src/utils/sanity.ts
+++ b/src/utils/sanity.ts
@@ -7,9 +7,6 @@ export const VERSION_PREFIX = 'versions.';
  */
 export const getSanityDocumentId = (val: string): string => {
   if (val.startsWith(DRAFTS_PREFIX)) return val.slice(DRAFTS_PREFIX.length);
-  if (val.startsWith(VERSION_PREFIX)) {
-    const withoutVersion = val.slice(VERSION_PREFIX.length);
-    return withoutVersion.slice(withoutVersion.indexOf('.') + 1);
-  }
+  if (val.startsWith(VERSION_PREFIX)) return val.slice(val.indexOf('.', VERSION_PREFIX.length) + 1);
   return val;
 };


### PR DESCRIPTION
Ticket: Resolves #78 

## Description of changes

While forcing compatibility with newer versions of the Sanity CMS, the Page Tree version works well still with Studio versions 4 and 5 without much issue. Where compatibility breaks is with Sanity’s Scheduled Drafts.

When using Scheduled Drafts, you’ll see validation issues with the slug in the newer `versions.` prefix and see the page in the site tree twice.

Site Tree:
<img width="302" height="82" alt="image" src="https://github.com/user-attachments/assets/9da64ebe-5283-45aa-b336-e7ad7a0f93a2" />

Slug Validation on a Version:
<img width="1938" height="356" alt="image" src="https://github.com/user-attachments/assets/05873c38-5c59-4ae8-8351-5fd80cfc4978" />

<img width="601" height="423" alt="Screenshot 2026-04-06 at 2 47 58 PM" src="https://github.com/user-attachments/assets/f5cb93f5-96a6-4ce0-bb31-ad1432e0810a" />

This pull request fixes compatibility with Scheduled Drafts. This may also fix compatibility with Content Releases, but I haven’t had the ability to test with those at this time.

## How to validate the changes

1. Install on a Sanity CMS version that supports Scheduled Drafts
2. Create a document that uses a slug field
3. Create a scheduled draft of that document
4. View the scheduled draft schedule page where there are no validation issues with the slug field
5. View the site tree where the document is not duplicated

## ✅ Definition of Done

This checklist helps with risk management during software development. It is not a mandatory list to fully check off, but a basis for thinking about quality, safety, and best practices. Feel free to adapt it for your own project — as long as the risks are consciously managed.

### 📄 Documentation & Knowledge Sharing

- [x] Changes are documented in the code and/or `README.md`
- [ ] Relevant Notion pages are updated

### 🧪 Testing & Quality

- [ ] Changes are covered by unit/integration/end-to-end tests
- [ ] GitHub Actions (CI/CD) pass successfully
- [x] Reviewer has tested and verified the changes locally

### 📊 Monitoring & Performance

- [ ] Relevant metrics (e.g. in Datadog) are added or updated
- [ ] Performance and scalability have been considered and tested if needed

### 🔐 Security & Privacy

- [ ] The changes comply with our [Secure software development policy](https://www.notion.so/q42/12-Secure-software-development-policy-3be5262f736c4a2a854fa2543d90c8be?pvs=4)
- [x] No personal data or privacy-sensitive information is affected
- [x] Input validation, authentication, and authorization are properly handled

### 🧩 Traceability & Readiness

- [ ] A Jira ticket is linked, and the ticket number is in the PR title (e.g. `[R2025-1234] Meaningful title`)
- [ ] No unresolved `TODO`s remain in the code (unless followed up with a Jira ticket)

### 🤝 Review & Collaboration

- [ ] Code is reviewed by at least one team member
- [ ] Merge responsibility and timing are agreed upon
- [ ] Team members are informed (e.g. via Slack or daily stand-up)
