### PR TITLE
Prevent 'Parent slug' being edited when document is readOnly

### DIFF
--- a/src/components/PageTreeInput.tsx
+++ b/src/components/PageTreeInput.tsx
@@ -89,10 +89,10 @@ export const PageTreeInput = (
         ) : (
           <Card padding={1} shadow={1} radius={2}>
             <Flex>
-              <SelectedItemCard padding={3} radius={2} onClick={openDialog} flex={1}>
+              <SelectedItemCard padding={3} radius={2} onClick={props.readOnly ? undefined : openDialog} flex={1}>
                 <Text size={2}>{parentId ? (parentPath ?? 'Select page') : 'Select page'}</Text>
               </SelectedItemCard>
-              {parentId && (
+              {parentId && !props.readOnly && (
                 <Box marginLeft={2}>
                   <Button mode="ghost" padding={3} text="Remove" onClick={resetValue} />
                 </Box>

--- a/src/components/PageTreeInput.tsx
+++ b/src/components/PageTreeInput.tsx
@@ -126,9 +126,10 @@ export const PageTreeInput = (
 };
 
 const SelectedItemCard = styled(Card)<{ theme: Theme }>`
-  cursor: pointer;
+  cursor: ${({ onClick }) => (onClick ? 'pointer' : 'default')};
 
   &:hover {
-    background-color: ${({ theme }) => theme.sanity.v2?.color.selectable.neutral.hovered.bg};
+    background-color: ${({ theme, onClick }) =>
+      onClick ? theme.sanity.v2?.color.selectable.neutral.hovered.bg : undefined};
   }
 `;


### PR DESCRIPTION
This Pull Request adds some logic to prevent 'Parent slug' from (attempting to) being edited when a document is in a read-only state. Example of this would include when a schema is marked as read only, or when a document is in the 'published' perspective without drafts being disabled.

This solves an error when a CMS user will attempt to edit it in this state, triggering an `Uncaught Error: Attempted to patch a read-only document` in the Studio.